### PR TITLE
chore: migrate reward distribution from RIVER to TOWNS

### DIFF
--- a/src/llama-scripts/DistributeRewardsV2Script.sol
+++ b/src/llama-scripts/DistributeRewardsV2Script.sol
@@ -12,16 +12,16 @@ contract DistributeRewardsV2ScriptBase is LlamaBaseScript {
   IRegistryDiamond public constant REGISTRY_DIAMOND = IRegistryDiamond(0x7c0422b31401C936172C897802CF0373B35B7698);
 
   /// @notice The Treasury Llama account address.
-  LlamaAccount public constant RIVER_TREASURY = LlamaAccount(payable(0x8ee48C016b932A69779A25133b53F0fFf66C85C0));
+  LlamaAccount public constant TOWNS_TREASURY = LlamaAccount(payable(0x8ee48C016b932A69779A25133b53F0fFf66C85C0));
 
-  /// @notice The RVR ERC20 token address.
-  IERC20 public constant RVR_TOKEN = IERC20(0x91930fd11ABAa5241241d3B07c02A8d0B5ac1920);
+  /// @notice The TOWNS ERC20 token address.
+  IERC20 public constant TOWNS_TOKEN = IERC20(0x00000000A22C618fd6b4D7E9A335C4B96B189a38);
 
   function distributeRewards() external onlyDelegateCall {
     uint256 rewardAmount = REGISTRY_DIAMOND.getPeriodRewardAmount();
 
-    RIVER_TREASURY.transferERC20(
-      LlamaAccount.ERC20Data({token: RVR_TOKEN, recipient: address(REGISTRY_DIAMOND), amount: rewardAmount})
+    TOWNS_TREASURY.transferERC20(
+      LlamaAccount.ERC20Data({token: TOWNS_TOKEN, recipient: address(REGISTRY_DIAMOND), amount: rewardAmount})
     );
 
     REGISTRY_DIAMOND.notifyRewardAmount(rewardAmount);
@@ -34,16 +34,16 @@ contract DistributeRewardsV2ScriptBaseSepolia is LlamaBaseScript {
   IRegistryDiamond public constant REGISTRY_DIAMOND = IRegistryDiamond(0x08cC41b782F27d62995056a4EF2fCBAe0d3c266F);
 
   /// @notice The Treasury Llama account address.
-  LlamaAccount public constant RIVER_TREASURY = LlamaAccount(payable(0x8ee48C016b932A69779A25133b53F0fFf66C85C0));
+  LlamaAccount public constant TOWNS_TREASURY = LlamaAccount(payable(0x8ee48C016b932A69779A25133b53F0fFf66C85C0));
 
-  /// @notice The RVR ERC20 token address.
-  IERC20 public constant RVR_TOKEN = IERC20(0x24e3123E1b30E041E2df26Da9d6140c5B07Fe4F0);
+  /// @notice The TOWNS ERC20 token address.
+  IERC20 public constant TOWNS_TOKEN = IERC20(0x00000000A22C618fd6b4D7E9A335C4B96B189a38);
 
   function distributeRewards() external onlyDelegateCall {
     uint256 rewardAmount = REGISTRY_DIAMOND.getPeriodRewardAmount();
 
-    RIVER_TREASURY.transferERC20(
-      LlamaAccount.ERC20Data({token: RVR_TOKEN, recipient: address(REGISTRY_DIAMOND), amount: rewardAmount})
+    TOWNS_TREASURY.transferERC20(
+      LlamaAccount.ERC20Data({token: TOWNS_TOKEN, recipient: address(REGISTRY_DIAMOND), amount: rewardAmount})
     );
 
     REGISTRY_DIAMOND.notifyRewardAmount(rewardAmount);

--- a/src/river-scripts/DistributeRewardsV2.t.sol
+++ b/src/river-scripts/DistributeRewardsV2.t.sol
@@ -18,14 +18,14 @@ import {IERC20} from "@openzeppelin/token/ERC20/IERC20.sol";
 
 // Base Sepolia test
 contract DistributeRewardsV2BaseSepolia is LlamaTestSetup {
-  // RIVER_EXECUTOR, RIVER_CORE addresses identical on base, base_sepolia
-  address internal constant RIVER_EXECUTOR = 0x63217D4c321CC02Ed306cB3843309184D347667B;
-  address internal constant RIVER_CORE = 0xA547373eB2b3c93AdeB27ec72133Fb7B92F70F7f;
+  // TOWNS_EXECUTOR, TOWNS_CORE addresses identical on base, base_sepolia
+  address internal constant TOWNS_EXECUTOR = 0x63217D4c321CC02Ed306cB3843309184D347667B;
+  address internal constant TOWNS_CORE = 0xA547373eB2b3c93AdeB27ec72133Fb7B92F70F7f;
   /// @dev The Treasury Llama account address.
-  address internal constant RIVER_TREASURY = 0x8ee48C016b932A69779A25133b53F0fFf66C85C0;
-  /// @dev The RVR ERC20 token address.
-  IOptimismMintableERC20 internal constant RVR_TOKEN =
-    IOptimismMintableERC20(0x24e3123E1b30E041E2df26Da9d6140c5B07Fe4F0);
+  address internal constant TOWNS_TREASURY = 0x8ee48C016b932A69779A25133b53F0fFf66C85C0;
+  /// @dev The TOWNS ERC20 token address.
+  IOptimismMintableERC20 internal constant TOWNS_TOKEN =
+    IOptimismMintableERC20(0x00000000A22C618fd6b4D7E9A335C4B96B189a38);
   /// @dev The Base Bridge.
   address internal constant BRIDGE_BASE = 0x4200000000000000000000000000000000000010;
 
@@ -37,36 +37,39 @@ contract DistributeRewardsV2BaseSepolia is LlamaTestSetup {
   DistributeRewardsV2ScriptBaseSepolia internal rewardsScript;
 
   function setUp() public override {
-    vm.createSelectFork("base_sepolia", 19_351_800);
+    vm.createSelectFork("base_sepolia", 21_724_000);
 
     rewardsScript = new DistributeRewardsV2ScriptBaseSepolia();
 
     uint256 periodAmount = REWARDS_DISTRIBUTION.getPeriodRewardAmount();
-    // mint a little more than period amount to RIVER_TREASURY
+    // mint a little more than period amount to TOWNS_TREASURY
     vm.prank(BRIDGE_BASE);
-    RVR_TOKEN.mint(RIVER_TREASURY, periodAmount);
+    TOWNS_TOKEN.mint(TOWNS_TREASURY, periodAmount);
   }
 
   function test_BaseSepolia_DistributeRewards() public {
     // Authorize script
-    vm.prank(address(RIVER_EXECUTOR));
-    LlamaCore(RIVER_CORE).setScriptAuthorization(address(rewardsScript), true);
+    vm.prank(address(TOWNS_EXECUTOR));
+    LlamaCore(TOWNS_CORE).setScriptAuthorization(address(rewardsScript), true);
 
     // Call distributeRewardsFromTreasury
-    vm.prank(address(RIVER_CORE));
-    LlamaExecutor(RIVER_EXECUTOR).execute(address(rewardsScript), true, abi.encodeWithSignature("distributeRewards()"));
+    vm.prank(address(TOWNS_CORE));
+    (bool success,) = LlamaExecutor(TOWNS_EXECUTOR).execute(
+      address(rewardsScript), true, abi.encodeWithSignature("distributeRewards()")
+    );
+    assertTrue(success);
   }
 }
 
 // Base test
 contract DistributeRewardsV2Base is LlamaTestSetup {
-  address internal constant RIVER_EXECUTOR = 0x63217D4c321CC02Ed306cB3843309184D347667B;
-  address internal constant RIVER_CORE = 0xA547373eB2b3c93AdeB27ec72133Fb7B92F70F7f;
+  address internal constant TOWNS_EXECUTOR = 0x63217D4c321CC02Ed306cB3843309184D347667B;
+  address internal constant TOWNS_CORE = 0xA547373eB2b3c93AdeB27ec72133Fb7B92F70F7f;
   /// @dev The Treasury Llama account address.
-  address internal constant RIVER_TREASURY = 0x8ee48C016b932A69779A25133b53F0fFf66C85C0;
-  /// @dev The RVR ERC20 token address.
-  IOptimismMintableERC20 internal constant RVR_TOKEN =
-    IOptimismMintableERC20(0x91930fd11ABAa5241241d3B07c02A8d0B5ac1920);
+  address internal constant TOWNS_TREASURY = 0x8ee48C016b932A69779A25133b53F0fFf66C85C0;
+  /// @dev The TOWNS ERC20 token address.
+  IOptimismMintableERC20 internal constant TOWNS_TOKEN =
+    IOptimismMintableERC20(0x00000000A22C618fd6b4D7E9A335C4B96B189a38);
   /// @dev The Base Bridge.
   address internal constant BRIDGE_BASE = 0x4200000000000000000000000000000000000010;
 
@@ -78,23 +81,26 @@ contract DistributeRewardsV2Base is LlamaTestSetup {
   DistributeRewardsV2ScriptBase public rewardsScript;
 
   function setUp() public override {
-    vm.createSelectFork("base", 23_835_128);
+    vm.createSelectFork("base", 26_213_400);
 
     rewardsScript = new DistributeRewardsV2ScriptBase();
 
     uint256 periodAmount = REWARDS_DISTRIBUTION.getPeriodRewardAmount();
-    // mint a little more than period amount to RIVER_TREASURY
+    // mint a little more than period amount to TOWNS_TREASURY
     vm.prank(BRIDGE_BASE);
-    RVR_TOKEN.mint(RIVER_TREASURY, periodAmount);
+    TOWNS_TOKEN.mint(TOWNS_TREASURY, periodAmount);
   }
 
   function test_Base_DistributeRewards() public {
     // Authorize script
-    vm.prank(address(RIVER_EXECUTOR));
-    LlamaCore(RIVER_CORE).setScriptAuthorization(address(rewardsScript), true);
+    vm.prank(address(TOWNS_EXECUTOR));
+    LlamaCore(TOWNS_CORE).setScriptAuthorization(address(rewardsScript), true);
 
     // Call distributeRewardsFromTreasury
-    vm.prank(address(RIVER_CORE));
-    LlamaExecutor(RIVER_EXECUTOR).execute(address(rewardsScript), true, abi.encodeWithSignature("distributeRewards()"));
+    vm.prank(address(TOWNS_CORE));
+    (bool success,) = LlamaExecutor(TOWNS_EXECUTOR).execute(
+      address(rewardsScript), true, abi.encodeWithSignature("distributeRewards()")
+    );
+    assertTrue(success);
   }
 }


### PR DESCRIPTION
Updated constants, addresses, and token references from RIVER to TOWNS across reward distribution scripts and tests. This includes changes to treasury, token contracts, and associated functionality to align with the new TOWNS setup.